### PR TITLE
Feature/Post installation tasks to configure LDAP

### DIFF
--- a/files/LDAPsecret.yaml.j2
+++ b/files/LDAPsecret.yaml.j2
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  bindPassword: "{{ ldap_bindPassword }}"
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: "{{ ldap_secret_name }}"

--- a/files/Oauth.yaml.j2
+++ b/files/Oauth.yaml.j2
@@ -1,0 +1,30 @@
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+spec:
+  identityProviders:
+  # This provider name is prefixed to the returned user ID to form an identity name:
+  - name: "{{ ldap_idp_name }}"
+    # Controls how mappings are established between this provider’s identities and user objects:
+    mappingMethod: claim
+    type: LDAP
+    ldap:
+      attributes:
+        id:
+        - dn
+        email:
+        - mail
+        name:
+        - cn
+        preferredUsername:
+        - uid
+      bindDN: "{{ bindDN }}"
+      bindPassword:
+        name: "{{ ldap_secret_name }}"
+      # ca:
+        # name: ca-config-map1
+      # LDAP or LDAPS:
+      insecure: false
+      # An RFC 2255 URL which specifies the LDAP host and search parameters to use:
+      url: "{{ ldap_url }}"

--- a/install-upi.yaml
+++ b/install-upi.yaml
@@ -274,7 +274,7 @@
     - name: fix dns settings
       command: "{{ oc }} replace -f /tmp/{{ clustername }}/dnses.yaml"
       when: finish.stat.exists == False
-        
+
 #    - name: workaround for missing kubeadmin-password file
 #      copy:
 #        dest: "/tmp/{{ clustername }}/auth/kubeadmin-password"
@@ -316,4 +316,6 @@
           - ""
           - "API: https://api.{{ clustername }}.{{ publiczonename }}:6443"
           - "Web console: https://console-openshift-console.apps.{{ clustername }}.{{ publiczonename }}/"
+
+    - import_tasks: tasks/post_installation.yaml
 ...

--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -78,13 +78,13 @@ api_internal_only: false
 # Enable LDAP integration, disabled by default
 enable_ldap_integration: false
 # LDAP bind password, ideally should be in Ansible Vault or other secrets management tool
-ldap_bindPassword: "r3dh4t!"
+ldap_bindPassword: "SUPERSECRET"
 # Name for the LDAP secret containing LDAP password
 ldap_secret_name: "ldap-secret1"
 # LDAP identity provider name
 ldap_idp_name: "ldapidp1"
 # Bind DN
-bindDN: "a@X.nsw.gov.au"
+bindDN: "a@X.test.example.au"
 # LDAP URL
-ldap_url: "ldap://X.nsw.gov.au:389/OU=Users,OU=ad,DC=X,DC=nsw,DC=gov,DC=au"
+ldap_url: "ldap://X.test.example.au:389/OU=Users,OU=ad,DC=X,DC=test,DC=example,DC=au"
 ...

--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -71,4 +71,20 @@ bootstrap_cleanup: true
 # Enable this to only expose the API internally, requires ansible host to
 # be on the same network as cluster
 api_internal_only: false
+
+#########################
+# LDAP
+#########################
+# Enable LDAP integration, disabled by default
+enable_ldap_integration: false
+# LDAP bind password, ideally should be in Ansible Vault or other secrets management tool
+ldap_bindPassword: "r3dh4t!"
+# Name for the LDAP secret containing LDAP password
+ldap_secret_name: "ldap-secret1"
+# LDAP identity provider name
+ldap_idp_name: "ldapidp1"
+# Bind DN
+bindDN: "dmp-nonprod@ad.p.dmp.aws.hosting.transport.nsw.gov.au"
+# LDAP URL
+ldap_url: "ldap://ad.p.dmp.aws.hosting.transport.nsw.gov.au:389/OU=Users,OU=ad,DC=ad,DC=p,DC=dmp,DC=aws,DC=hosting,DC=transport,DC=nsw,DC=gov,DC=au?sAMAccountName"
 ...

--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -84,7 +84,7 @@ ldap_secret_name: "ldap-secret1"
 # LDAP identity provider name
 ldap_idp_name: "ldapidp1"
 # Bind DN
-bindDN: "dmp-nonprod@ad.p.dmp.aws.hosting.transport.nsw.gov.au"
+bindDN: "a@X.nsw.gov.au"
 # LDAP URL
-ldap_url: "ldap://ad.p.dmp.aws.hosting.transport.nsw.gov.au:389/OU=Users,OU=ad,DC=ad,DC=p,DC=dmp,DC=aws,DC=hosting,DC=transport,DC=nsw,DC=gov,DC=au?sAMAccountName"
+ldap_url: "ldap://X.nsw.gov.au:389/OU=Users,OU=ad,DC=X,DC=nsw,DC=gov,DC=au"
 ...

--- a/tasks/post_installation.yaml
+++ b/tasks/post_installation.yaml
@@ -1,0 +1,19 @@
+---
+
+- block:
+  - name: 1.0 | Creating LDAP secrets | tasks/post_installation.yaml
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'files/LDAPsecret.yaml.j2') }}"
+      validate:
+        fail_on_error: no
+        strict: yes
+
+  - name: 2.0 | Creating LDAP Custom Resource | tasks/post_installation.yaml
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'files/Oauth.yaml.j2') }}"
+      validate:
+        fail_on_error: no
+        strict: yes
+  when: enable_ldap_integration == true


### PR DESCRIPTION
### What is the relevant ticket?
None

#### What’s this PR do?
Add post-installation tasks to configure LDAP authentication (when `enable_ldap_integration: true` in `group_vars`)

#### Where should the reviewer start?
`install-upi.yaml`
`tasks/post_installation.yaml`
`inventory/group_vars/all`
`files/LDAPsecret.yaml.j2`
`files/Oauth.yaml.j2`

#### How should this be manually tested?
`ansible-playbook install-upi.yaml`

#### Risk involved?
Yes, potentially. Make sure the plain text `ldap_bindPassword` is not committed to the repository - security risk. LDAP authentication must be tested, to confirm it does not collide with other authentication types.

#### Screenshots (if appropriate):
N/A

#### Does the documentation or dependencies need an update?
`group_vars` variables for this change are well documented in the same place